### PR TITLE
Avoid amortising over holes or non-executable mappings

### DIFF
--- a/tests/feature_flags.c
+++ b/tests/feature_flags.c
@@ -3,6 +3,30 @@
 #include <stddef.h>
 #include <stdio.h>
 
+static __attribute__((noinline, cold)) void run_all_tail(void)
+{
+	if (DF_OPT(untouched, printf1)) {
+		printf("untouched:printf1\n");
+	}
+
+	if (DF_DEFAULT(untouched, printf2)) {
+		printf("untouched:printf2\n");
+	}
+
+	if (DF_DEFAULT(feature_flag, default_on)) {
+		printf("feature_flag:default_on\n");
+	}
+
+	if (DF_FEATURE(feature_flag, default_off,
+	    "DF_FEATURE flags are classic feature flags: off initially "
+	    "and if the dynamic_flag machine can't find them, "
+	    "and the compiler expects them to be disabled")) {
+		printf("feature_flag:default_off\n");
+	}
+
+	return;
+}
+
 static void
 run_all(void)
 {
@@ -37,25 +61,7 @@ run_all(void)
 		printf("test:on:printf3\n");
 	}
 
-	if (DF_OPT(untouched, printf1)) {
-		printf("untouched:printf1\n");
-	}
-
-	if (DF_DEFAULT(untouched, printf2)) {
-		printf("untouched:printf2\n");
-	}
-
-	if (DF_DEFAULT(feature_flag, default_on)) {
-		printf("feature_flag:default_on\n");
-	}
-
-	if (DF_FEATURE(feature_flag, default_off,
-	    "DF_FEATURE flags are classic feature flags: off initially "
-	    "and if the dynamic_flag machine can't find them, "
-	    "and the compiler expects them to be disabled")) {
-		printf("feature_flag:default_off\n");
-	}
-
+	run_all_tail();
 	return;
 }
 

--- a/tests/feature_flags.stdout.expected
+++ b/tests/feature_flags.stdout.expected
@@ -10,17 +10,17 @@ untouched:printf2
 feature_flag:default_on
 
 List all flags
-feature_flag:default_off@tests/feature_flags.c:55 (off): DF_FEATURE flags are classic feature flags: off initially and if the dynamic_flag machine can't find them, and the compiler expects them to be disabled
-feature_flag:default_on@tests/feature_flags.c:48 (1)
+feature_flag:default_off@tests/feature_flags.c:23 (off): DF_FEATURE flags are classic feature flags: off initially and if the dynamic_flag machine can't find them, and the compiler expects them to be disabled
+feature_flag:default_on@tests/feature_flags.c:16 (1)
 none:dummy@src/dynamic_flag.c:225 (off): This dummy flag does nothing. It lets the dynamic_flag library compile even when no other flag is defined.
-off:printf1@tests/feature_flags.c:12 (off): DF_OPT flags are usually disabled, but should always be safe to enable
-off:printf2@tests/feature_flags.c:16 (off)
-on:printf1@tests/feature_flags.c:21 (1): DF_DEFAULT flags are enabled initially and when the library can't find them.
-on:printf2@tests/feature_flags.c:27 (1): DF_DEFAULT_SLOW flags are enabled like DF_DEFAULT, but instruct the compiler to expect them to be disabled.
-on:printf3@tests/feature_flags.c:31 (1)
-test:on:printf3@tests/feature_flags.c:36 (off)
-untouched:printf1@tests/feature_flags.c:40 (off)
-untouched:printf2@tests/feature_flags.c:44 (1)
+off:printf1@tests/feature_flags.c:36 (off): DF_OPT flags are usually disabled, but should always be safe to enable
+off:printf2@tests/feature_flags.c:40 (off)
+on:printf1@tests/feature_flags.c:45 (1): DF_DEFAULT flags are enabled initially and when the library can't find them.
+on:printf2@tests/feature_flags.c:51 (1): DF_DEFAULT_SLOW flags are enabled like DF_DEFAULT, but instruct the compiler to expect them to be disabled.
+on:printf3@tests/feature_flags.c:55 (1)
+test:on:printf3@tests/feature_flags.c:60 (off)
+untouched:printf1@tests/feature_flags.c:8 (off)
+untouched:printf2@tests/feature_flags.c:12 (1)
 
 Initial:
 on:printf1

--- a/tests/feature_flags.stdout.expected
+++ b/tests/feature_flags.stdout.expected
@@ -12,7 +12,7 @@ feature_flag:default_on
 List all flags
 feature_flag:default_off@tests/feature_flags.c:55 (off): DF_FEATURE flags are classic feature flags: off initially and if the dynamic_flag machine can't find them, and the compiler expects them to be disabled
 feature_flag:default_on@tests/feature_flags.c:48 (1)
-none:dummy@src/dynamic_flag.c:224 (off): This dummy flag does nothing. It lets the dynamic_flag library compile even when no other flag is defined.
+none:dummy@src/dynamic_flag.c:225 (off): This dummy flag does nothing. It lets the dynamic_flag library compile even when no other flag is defined.
 off:printf1@tests/feature_flags.c:12 (off): DF_OPT flags are usually disabled, but should always be safe to enable
 off:printf2@tests/feature_flags.c:16 (off)
 on:printf1@tests/feature_flags.c:21 (1): DF_DEFAULT flags are enabled initially and when the library can't find them.


### PR DESCRIPTION
We only want to extend the mprotect-ed range by one page (up or down) at a time. I remember the extension criterion going through multiple rounds of rewriting for clarity, and in the end we got something that works for most statically linked executables, but not correct anymore. This PR should make the condition both clearer and correct (smoke test passes with regular and split .text linking).