### PR TITLE
dynamic_flag: offer new minimal write mode

### DIFF
--- a/include/dynamic_flag.h
+++ b/include/dynamic_flag.h
@@ -285,6 +285,18 @@ ssize_t dynamic_flag_list_fprintf_cb(void *ctx, const struct dynamic_flag_state 
  * It is safe if useless to call this function multiple times.
  */
 void dynamic_flag_init_lib(void);
+
+/**
+ * @brief Updates the "minimal write" flag (false by default).
+ *
+ * When the "minimal mode" flag is true, the dynamic_flag library
+ * attempts to minimise writes to binary code, in order to avoid
+ * copy-on-write.  This flag is false by default: fewer code paths
+ * means fewer hidden bugs.
+ *
+ * It is safe to call this function multiple times.
+ */
+void dynamic_flag_set_minimal_write_mode(bool is_minimal);
 #else
 
 #define dynamic_flag_activate_kind(KIND, PATTERN) dynamic_flag_dummy((PATTERN))
@@ -294,6 +306,7 @@ void dynamic_flag_init_lib(void);
 #define dynamic_flag_deactivate dynamic_flag_dummy
 #define dynamic_flag_unhook dynamic_flag_dummy
 #define dynamic_flag_rehook dynamic_flag_dummy
+#define dynamic_flag_set_minimal_write_mode(MODE) ((MODE) ? dynamic_flag_init_lib_dummy() : (void)0)
 #define dynamic_flag_init_lib dynamic_flag_init_lib_dummy
 #define dynamic_flag_list dynamic_flag_list_state_dummy
 

--- a/tests/feature_flags.c
+++ b/tests/feature_flags.c
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 static __attribute__((noinline, cold)) void run_all_tail(void)
 {
@@ -87,9 +88,6 @@ int
 main(int argc, char **argv)
 {
 
-	(void)argc;
-	(void)argv;
-
 	printf("Before init\n");
 	/*
 	 * Expected:
@@ -106,6 +104,10 @@ main(int argc, char **argv)
 	 */
 	run_all();
 	dynamic_flag_init_lib();
+
+	if (argc > 1) {
+		dynamic_flag_set_minimal_write_mode(atoi(argv[1]));
+	}
 
 	printf("\nList all flags\n");
 	/*

--- a/tests/feature_flags.stdout.expected
+++ b/tests/feature_flags.stdout.expected
@@ -10,17 +10,17 @@ untouched:printf2
 feature_flag:default_on
 
 List all flags
-feature_flag:default_off@tests/feature_flags.c:23 (off): DF_FEATURE flags are classic feature flags: off initially and if the dynamic_flag machine can't find them, and the compiler expects them to be disabled
-feature_flag:default_on@tests/feature_flags.c:16 (1)
-none:dummy@src/dynamic_flag.c:225 (off): This dummy flag does nothing. It lets the dynamic_flag library compile even when no other flag is defined.
-off:printf1@tests/feature_flags.c:36 (off): DF_OPT flags are usually disabled, but should always be safe to enable
-off:printf2@tests/feature_flags.c:40 (off)
-on:printf1@tests/feature_flags.c:45 (1): DF_DEFAULT flags are enabled initially and when the library can't find them.
-on:printf2@tests/feature_flags.c:51 (1): DF_DEFAULT_SLOW flags are enabled like DF_DEFAULT, but instruct the compiler to expect them to be disabled.
-on:printf3@tests/feature_flags.c:55 (1)
-test:on:printf3@tests/feature_flags.c:60 (off)
-untouched:printf1@tests/feature_flags.c:8 (off)
-untouched:printf2@tests/feature_flags.c:12 (1)
+feature_flag:default_off@tests/feature_flags.c:24 (off): DF_FEATURE flags are classic feature flags: off initially and if the dynamic_flag machine can't find them, and the compiler expects them to be disabled
+feature_flag:default_on@tests/feature_flags.c:17 (1)
+none:dummy@src/dynamic_flag.c:231 (off): This dummy flag does nothing. It lets the dynamic_flag library compile even when no other flag is defined.
+off:printf1@tests/feature_flags.c:37 (off): DF_OPT flags are usually disabled, but should always be safe to enable
+off:printf2@tests/feature_flags.c:41 (off)
+on:printf1@tests/feature_flags.c:46 (1): DF_DEFAULT flags are enabled initially and when the library can't find them.
+on:printf2@tests/feature_flags.c:52 (1): DF_DEFAULT_SLOW flags are enabled like DF_DEFAULT, but instruct the compiler to expect them to be disabled.
+on:printf3@tests/feature_flags.c:56 (1)
+test:on:printf3@tests/feature_flags.c:61 (off)
+untouched:printf1@tests/feature_flags.c:9 (off)
+untouched:printf2@tests/feature_flags.c:13 (1)
 
 Initial:
 on:printf1


### PR DESCRIPTION
It means more branches, and thus more hiding places for bugs, but sometimes you really want to avoid copy-on-write traffic for no-op updates.

Exercised by adding an optional command-line argument to `feature_flags.c`.